### PR TITLE
enable extra-infos, reference-number, due-date

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -42,6 +42,7 @@ LABELS = {
         'fr': 'Payable par (nom/adresse)',
         'it': 'Pagabile da (nome/indirizzo)',
     },
+    'Payable by ': {'de': 'Zahlbar bis', 'fr': 'Payable jusque au', 'it': 'Pagabile fino al'},
     'In favour of': {'de': 'Zugunsten', 'fr': 'En faveur de', 'it': 'A favore di'},
 }
 
@@ -265,7 +266,8 @@ class QRBill:
             y_pos += 1
             dwg.add(dwg.text(self.label("Reference"), (margin, '%smm' % y_pos), **head_font_info))
             y_pos += line_space
-            dwg.add(dwg.text(self.ref_number, (margin, '%smm' % y_pos), **font_info))
+            dwg.add(dwg.text(
+                format_ref_number(self.ref_type, self.ref_number), (margin, '%smm' % y_pos), **font_info))
             y_pos += line_space
 
         y_pos += 1
@@ -370,7 +372,8 @@ class QRBill:
 
         if self.ref_number:
             add_header(self.label("Reference"))
-            dwg.add(dwg.text(self.ref_number, (payment_detail_left, '%smm' % y_pos), **font_info))
+            dwg.add(dwg.text(
+                format_ref_number(self.ref_type, self.ref_number), (payment_detail_left, '%smm' % y_pos), **font_info))
             y_pos += line_space
 
         if self.extra_infos:
@@ -406,7 +409,7 @@ class QRBill:
                 y_pos += line_space
 
         if self.due_date:
-            add_header(self.label("Payable by"))
+            add_header(self.label("Payable by "))
             dwg.add(dwg.text(
                 format_date(self.due_date), (payment_detail_left, '%smm' % y_pos), **font_info
             ))
@@ -426,6 +429,24 @@ def format_iban(iban):
     return '%s %s %s %s %s %s' % (
         iban[:4], iban[4:8], iban[8:12], iban[12:16], iban[16:20], iban[20:]
     )
+
+
+def format_ref_number(ref_type, ref_number):
+    if not ref_number:
+        return ''
+    if ref_type == "QRR":
+        return '%s %s %s %s %s %s' % (
+            ref_number[:2], ref_number[2:7], ref_number[7:12], ref_number[12:17], ref_number[17:22], ref_number[22:]
+        )
+    elif ref_type == "SCOR":
+        print_ref_number = ""
+        while ref_number:
+            print_ref_number = print_ref_number + " " + ref_number[0:4]
+            ref_number = ref_number[4:]
+        return print_ref_number.strip()
+    else:
+        return ref_number
+
 
 
 def format_date(date_):

--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -64,6 +64,8 @@ if __name__ == '__main__':
             currency=args.currency,
             due_date=args.due_date,
             debtor=debtor,
+            ref_number=args.reference_number,
+            extra_infos=args.extra_infos,
             language=args.language,
         )
     except ValueError as err:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name='qrbill',
-    version='0.2',
+    version='0.3',
     description='A library to generate Swiss QR-bill payment slips',
     license='GPLv3',
     author='Claude Paroz',


### PR DESCRIPTION
- pass extra_infos to init
  --extra-infos was not printed because the parameter was not passed

- pass ref_number to init
  --reference-number was not printed because the parameter was not passed

- format reference number according to specs
  formatting of reference numbers is with a space after 2 digits and then after every 5 digits
  formatting of the other type of reference number is with a space after every 4 characters

- enable printing of due-date
  due-date was never printed because it used the same label as debtor-name; the
  trailing space on the newly created label will be invisible when printing, but it does
  allow to distinguish due-date and debtor-name

- bump version