### PR TITLE
V0.4dev1.1

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -125,7 +125,7 @@ class QRBill:
                 raise ValueError("If provided, the amount must match the pattern '###.##'")
         self.amount = amount
         if currency not in self.allowed_currencies:
-            raise ValueError("Currency can only contains: %s" % ", ".join(self.allowed_currencies))
+            raise ValueError("Currency can only contain: %s" % ", ".join(self.allowed_currencies))
         self.currency = currency
         if due_date:
             m = re.match(DATE_REGEX, due_date)

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -163,7 +163,7 @@ class QRBill:
         else:
             self.ref_type = 'SCOR'
         self.ref_number = ref_number
-        if len(extra_infos) > 140:
+        if extra_infos and len(extra_infos) > 140:
             raise ValueError("Additional information cannot contain more than 140 characters")
         self.extra_infos = extra_infos
         if language not in ['en', 'de', 'fr', 'it']:

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -72,6 +72,11 @@ class Address:
         self.city = city
         if not country:
             country = 'CH'
+        # allow users to write the country as if used in an address in the local language
+        if str.lower(country) in ['schweiz', 'suisse', 'svizzera', 'svizra']:
+            country = 'CH'
+        if str.lower(country) in ['fürstentum liechtenstein']:
+            country = 'LI'
         try:
             countries.get(country)
         except KeyError:

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -9,6 +9,7 @@ import validators
 from iso3166 import countries
 
 IBAN_CH_LENGTH = 21
+IBAN_ALLOWED_COUNTRIES = ['CH', 'LI']
 AMOUNT_REGEX = r'\d{0,9}\.\d{2}'
 DATE_REGEX = r'(\d{4})-(\d{2})-(\d{2})'
 MM_TO_UU = 3.543307
@@ -113,8 +114,10 @@ class QRBill:
         if not account:
             raise ValueError("The account parameter is mandatory")
         account = account.replace(' ', '')
+        if account[:2] not in IBAN_ALLOWED_COUNTRIES:
+            raise ValueError("IBAN must start with: %s" % ", ".join(IBAN_ALLOWED_COUNTRIES))
         if account and len(account) != IBAN_CH_LENGTH:
-            raise ValueError("IBAN must have exactly 21 characters")
+            raise ValueError("IBAN must have exactly %s characters" % (IBAN_CH_LENGTH,))
         elif account and not validators.iban(account):
             raise ValueError("Sorry, the IBAN is not valid")
         self.account = account

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -10,7 +10,7 @@ from iso3166 import countries
 
 IBAN_CH_LENGTH = 21
 IBAN_ALLOWED_COUNTRIES = ['CH', 'LI']
-AMOUNT_REGEX = r'\d{0,9}\.\d{2}'
+AMOUNT_REGEX = r'^\d{1,9}\.\d{2}$'
 DATE_REGEX = r'(\d{4})-(\d{2})-(\d{2})'
 MM_TO_UU = 3.543307
 
@@ -123,9 +123,23 @@ class QRBill:
         self.account = account
 
         if amount is not None:
+            # remove commonly used thousands separators
+            amount = amount.replace("'","")
+            amount = amount.replace(",","")
+            # people often don't add .00 for amounts without cents/rappen
+            if not "." in amount:
+                amount = amount + ".00"
+            # strip leading zeros
+            amount = amount.lstrip("0")
+            # some people tend to strip the leading zero on amounts below 1 CHF/EUR
+            # and with removing leading zeros, we would have removed the zero before
+            # the decimal delimiter anyway
+            if amount[0] == ".":
+                amount = "0" + amount
             m = re.match(AMOUNT_REGEX, amount)
             if not m:
-                raise ValueError("If provided, the amount must match the pattern '###.##'")
+                raise ValueError("If provided, the amount must match the pattern '###.##'" +
+                                 " and can not be larger than 999'999'999.99")
         self.amount = amount
         if currency not in self.allowed_currencies:
             raise ValueError("Currency can only contain: %s" % ", ".join(self.allowed_currencies))

--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     parser.add_argument('--creditor-city', required=True,
                         help='creditor city')
     parser.add_argument('--creditor-country', default='CH',
-                        help='creditor country')
+                        help='creditor country (in English or 2-letter code)')
     parser.add_argument('--ucreditor-name',
                         help='ulitmate creditor name')
     parser.add_argument('--ucreditor-street',
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     parser.add_argument('--ucreditor-city',
                         help='ultimate creditor city')
     parser.add_argument('--ucreditor-country', default='CH',
-                        help='ultimate creditor country')
+                        help='ultimate creditor country (in English or 2-letter code)')
     parser.add_argument('--amount',
                         help='amount of payment')
     parser.add_argument('--currency', default='CHF', choices=['CHF', 'EUR'],
@@ -53,7 +53,7 @@ if __name__ == '__main__':
     parser.add_argument('--debtor-city',
                         help='debtor city')
     parser.add_argument('--debtor-country', default='CH',
-                        help='debtor country')
+                        help='debtor country (in English or 2-letter code)')
     parser.add_argument('--reference-number',
                         help='reference number')
     parser.add_argument('--extra-infos',

--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -8,32 +8,58 @@ from qrbill import QRBill
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--output')
-    parser.add_argument('--account', required=True)
-    parser.add_argument('--creditor-name', required=True)
-    parser.add_argument('--creditor-street')
-    parser.add_argument('--creditor-housenumber')
-    parser.add_argument('--creditor-postalcode', required=True)
-    parser.add_argument('--creditor-city', required=True)
-    parser.add_argument('--creditor-country', default='CH')
-    parser.add_argument('--ucreditor-name')
-    parser.add_argument('--ucreditor-street')
-    parser.add_argument('--ucreditor-housenumber')
-    parser.add_argument('--ucreditor-postalcode')
-    parser.add_argument('--ucreditor-city')
-    parser.add_argument('--ucreditor-country', default='CH')
-    parser.add_argument('--amount')
-    parser.add_argument('--currency', default='CHF')
-    parser.add_argument('--due-date')
-    parser.add_argument('--debtor-name')
-    parser.add_argument('--debtor-street')
-    parser.add_argument('--debtor-housenumber')
-    parser.add_argument('--debtor-postalcode')
-    parser.add_argument('--debtor-city')
-    parser.add_argument('--debtor-country', default='CH')
-    parser.add_argument('--reference-number')
-    parser.add_argument('--extra-infos')
-    parser.add_argument('--language', default='en')
+    parser.add_argument('--output',
+                        help='output file')
+    parser.add_argument('--account', required=True,
+                        help='creditor IBAN account number')
+    parser.add_argument('--creditor-name', required=True,
+                        help='creditor name')
+    parser.add_argument('--creditor-street',
+                        help='creditor street')
+    parser.add_argument('--creditor-housenumber',
+                        help='creditor house number')
+    parser.add_argument('--creditor-postalcode', required=True,
+                        help='creditor postal code')
+    parser.add_argument('--creditor-city', required=True,
+                        help='creditor city')
+    parser.add_argument('--creditor-country', default='CH',
+                        help='creditor country')
+    parser.add_argument('--ucreditor-name',
+                        help='ulitmate creditor name')
+    parser.add_argument('--ucreditor-street',
+                        help='ultimate creditor street')
+    parser.add_argument('--ucreditor-housenumber',
+                        help='ultimate creditor house number')
+    parser.add_argument('--ucreditor-postalcode',
+                        help='ultimate creditor postal code')
+    parser.add_argument('--ucreditor-city',
+                        help='ultimate creditor city')
+    parser.add_argument('--ucreditor-country', default='CH',
+                        help='ultimate creditor country')
+    parser.add_argument('--amount',
+                        help='amount of payment')
+    parser.add_argument('--currency', default='CHF', choices=['CHF', 'EUR'],
+                        help='currency of payment')
+    parser.add_argument('--due-date',
+                        help='due date of payment in the form YYYY-MM-DD')
+    parser.add_argument('--debtor-name',
+                        help='debtor name')
+    parser.add_argument('--debtor-street',
+                        help='debtor street')
+    parser.add_argument('--debtor-housenumber',
+                        help='debtor house number')
+    parser.add_argument('--debtor-postalcode',
+                        help='debtor postal code')
+    parser.add_argument('--debtor-city',
+                        help='debtor city')
+    parser.add_argument('--debtor-country', default='CH',
+                        help='debtor country')
+    parser.add_argument('--reference-number',
+                        help='reference number')
+    parser.add_argument('--extra-infos',
+                        help='payment purpose')
+    parser.add_argument('--language', default='en', choices=['en', 'de', 'fr', 'it'],
+                        help='language')
 
     args = parser.parse_args()
     creditor = {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with readme.open() as f:
 
 setup(
     name='qrbill',
-    version='0.3',
+    version='0.4.dev1',
     description='A library to generate Swiss QR-bill payment slips',
     long_description=long_description,
     license='GPLv3',

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -39,6 +39,32 @@ class QRBillTests(unittest.TestCase):
         self.assertEqual(bill.account, "CH4431999123000889012")
         self.assertEqual(format_iban('CH4431999123000889012'), 'CH44 3199 9123 0008 8901 2')
 
+    def test_currency(self):
+        with self.assertRaisesRegex(ValueError, "Currency can only contain: CHF, EUR"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                currency="USD",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                currency="CHF",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        self.assertEqual(bill.currency, "CHF")
+        bill = QRBill(
+            account="CH 44 3199 9123 0008 89012",
+            currency="EUR",
+            creditor={
+                'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+            },
+        )
+        self.assertEqual(bill.currency, "EUR")
+
     def test_minimal_data(self):
         bill = QRBill(
             account="CH 44 3199 9123 0008 89012",

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -29,6 +29,13 @@ class QRBillTests(unittest.TestCase):
                     'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
                 },
             )
+        with self.assertRaisesRegex(ValueError, "IBAN must start with: CH, LI"):
+            bill = QRBill(
+                account="DE 44 3199 9123 0008 89012",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
         # Spaces are auto-stripped
         bill = QRBill(
             account="CH 44 3199 9123 0008 89012",

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -72,6 +72,43 @@ class QRBillTests(unittest.TestCase):
         )
         self.assertEqual(bill.currency, "EUR")
 
+    def test_amount(self):
+        with self.assertRaisesRegex(ValueError, "If provided, the amount must match the pattern '###.##'" +
+                                    " and can not be larger than 999'999'999.99"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="1234567890.00",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        with self.assertRaisesRegex(ValueError, "If provided, the amount must match the pattern '###.##'" +
+                                    " and can not be larger than 999'999'999.99"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="1.001",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        with self.assertRaisesRegex(ValueError, "If provided, the amount must match the pattern '###.##'" +
+                                    " and can not be larger than 999'999'999.99"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="CHF800",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="0,001'800",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        self.assertEqual(bill.amount, "1800.00")
+
     def test_minimal_data(self):
         bill = QRBill(
             account="CH 44 3199 9123 0008 89012",


### PR DESCRIPTION
a number of suggested improvements

- I bumped the version to a development level, as I have some more
  suggested adaptions in the pipeline and in my head. But I am not
  sure how you want your versioning to be done.

  This is a separate commit, you you can easily skip it, if you are not
  happy with this versioning.

  Possibly you might want to create a development branch (one of
  the changes in my pipeline depends on changes in another library,
  all of them but one already accepted and commited, but not yet
  released).

- Added help texts to the argument parser.
  
  Also restricted some arguments to some predefined choices
  where only those choices are valid.

- Restrict accepted account (IBAN) numbers to CH and LI; according
  to the online specifications, these are the only ones accepteable.

- Fix a runtime error when no --extra-info is given.
  len(extra_infos) is invalid when None is passed to __init__ from the
  argument parser for extra_infos.

- improve checking of valid amount.
  Any number of digits after the decimal point were possible.
  Allow for thousands separators on input.
  Add .00 if no rappen/cents are specified in the input.
  Accoding to the specs, there is a maximum length for amount,
  which was not checked and could be exceeded before.

- Accpet the country entered in the local language.
  Only ISO-2-letter codes and English were accepted, but when
  entering an address, people certainly expect to be able to specify
  the country in the local language, like the rest of the address. Make
  this possible, but only for CH and LI, as the whole libraray is for
  CH/LI QR-bills only.