### PR TITLE
accept the country entered in the local language

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -72,6 +72,11 @@ class Address:
         self.city = city
         if not country:
             country = 'CH'
+        # allow users to write the country as if used in an address in the local language
+        if str.lower(country) in ['schweiz', 'suisse', 'svizzera', 'svizra']:
+            country = 'CH'
+        if str.lower(country) in ['fürstentum liechtenstein']:
+            country = 'LI'
         try:
             countries.get(country)
         except KeyError:

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -194,6 +194,51 @@ class CommandLineTests(unittest.TestCase):
         ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         self.assertEqual(err, b'')
 
+    def test_country_args(self):
+        with tempfile.NamedTemporaryFile(suffix='.svg') as tmp:
+            # Switzerland - German
+            out, err = subprocess.Popen([
+                sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
+                '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
+                '--creditor-city', 'Lausanne', '--creditor-country', 'Schweiz',
+                '--output', tmp.name,
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            self.assertEqual(err, b'')
+            # Switzerland - French
+            out, err = subprocess.Popen([
+                sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
+                '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
+                '--creditor-city', 'Lausanne', '--creditor-country', 'Suisse',
+                '--output', tmp.name,
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            self.assertEqual(err, b'')
+            # Switzerland - Italian
+            out, err = subprocess.Popen([
+                sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
+                '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
+                '--creditor-city', 'Lausanne', '--creditor-country', 'Svizzera',
+                '--output', tmp.name,
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            self.assertEqual(err, b'')
+            # Switzerland - Romansh
+            out, err = subprocess.Popen([
+                sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
+                '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
+                '--creditor-city', 'Lausanne', '--creditor-country', 'Svizra',
+                '--output', tmp.name,
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            self.assertEqual(err, b'')
+            # Liechtenstein - German
+            out, err = subprocess.Popen([
+                sys.executable, 'scripts/qrbill', '--account', 'LI 21 08810 0002324013AA',
+                '--creditor-name',  'Jane', '--creditor-postalcode', '9490',
+                '--creditor-city', 'Vaduz', '--creditor-country', 'Fürstentum Liechtenstein',
+                '--output', tmp.name,
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            self.assertEqual(err, b'')
+
+
+
     def test_svg_result(self):
         with tempfile.NamedTemporaryFile(suffix='.svg') as tmp:
             cmd = [


### PR DESCRIPTION
- the code only allowed for the country to be entered
  in the ISO-3166 2-letter form or in English, but people
  are much more likely to add it in the local language,
  just as when they specify a normal address; thus accept
  the values for CH and LI (this whole library is specific
  to payment slips for CH and LI) in the local languages

As discussed already, Switzerland and Liechtenstein do not need to be added, as the iso3166 module verifies English names correctly (just as alpha2 / alpha3 / number).