### PR TITLE
prevent test from creating svg file in current dir

### DIFF
--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -187,12 +187,14 @@ class CommandLineTests(unittest.TestCase):
         )
 
     def test_minimal_args(self):
-        out, err = subprocess.Popen([
-            sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
-            '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
-            '--creditor-city', 'Lausanne',
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-        self.assertEqual(err, b'')
+        with tempfile.NamedTemporaryFile(suffix='.svg') as tmp:
+            out, err = subprocess.Popen([
+                sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
+                '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
+                '--creditor-city', 'Lausanne',
+                '--output', tmp.name,
+            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+            self.assertEqual(err, b'')
 
     def test_svg_result(self):
         with tempfile.NamedTemporaryFile(suffix='.svg') as tmp:


### PR DESCRIPTION
I think the tests should cleanup after themselves and not leave files.