### PR TITLE
improve checking of valid amount

### DIFF
--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -72,6 +72,51 @@ class QRBillTests(unittest.TestCase):
         )
         self.assertEqual(bill.currency, "EUR")
 
+    def test_amount(self):
+        with self.assertRaisesRegex(ValueError, "If provided, the amount must match the pattern '###.##'" +
+                                    " and can not be larger than 999'999'999.99"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="1234567890.00",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        with self.assertRaisesRegex(ValueError, "If provided, the amount must match the pattern '###.##'" +
+                                    " and can not be larger than 999'999'999.99"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="1.001",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        with self.assertRaisesRegex(ValueError, "If provided, the amount must match the pattern '###.##'" +
+                                    " and can not be larger than 999'999'999.99"):
+            bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="CHF800",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount=".5",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        self.assertEqual(bill.amount, "0.50")
+        bill = QRBill(
+                account="CH 44 3199 9123 0008 89012",
+                amount="001'800",
+                creditor={
+                    'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
+                },
+            )
+        self.assertEqual(bill.amount, "1800.00")
+
     def test_minimal_data(self):
         bill = QRBill(
             account="CH 44 3199 9123 0008 89012",


### PR DESCRIPTION
- the REGEX was not sufficient, without start/end anchors
  it did also match amounts with more digits
- leading zeros must be removed
  see https://www.paymentstandards.ch/dam/downloads/ig-qr-bill-en.pdf
  chapter 4.3.3 element Amt
- on amounts below 1 CHF/EUR, it is cutomary to include one
  leading 0 in front of the decimal delimiter; yes, the spec
  says "without leading zeros", but that is most probably not
  true for amounts below 1 CHF/EUR
- (thought: negative values in payment slips are not possible,
   no need to take care of that in the regex)
- people are accustomed to use thousand-separators ('); let
  them do so by removing them from the passed amount
- people are accustomed to only type whole CHF/EUR amounts if
  there is no fraction and expect the software to add .00
  implicitly; make these people happy too, as well as those
  lazy ones who write 12.10 as 12.1 only


As already discussed, accept the `'` thousands delimiter, but not the `,`.
Also added one more twist: accept only one digit after the decimal point and add
a zero at the end in this case, so to make it ###.##.