### PR TITLE
V0.4dev1.10

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -200,12 +200,12 @@ class QRBill:
 
     def qr_data(self):
         """Return data to be encoded in the QR code."""
-        values = [self.qr_type, self.version, self.coding, self.account]
+        values = [self.qr_type or '', self.version or '', self.coding or '', self.account or '']
         values.extend(self.creditor.data_list())
         values.extend(self.final_creditor.data_list() if self.final_creditor else [''] * 7)
-        values.extend([self.amount or '', self.currency])
+        values.extend([self.amount or '', self.currency or ''])
         values.extend(self.debtor.data_list() if self.debtor else [''] * 7)
-        values.extend([self.ref_type, self.ref_number or '', self.extra_infos, 'EPD'])
+        values.extend([self.ref_type or '', self.ref_number or '', self.extra_infos or '', 'EPD'])
         return "\r\n".join([str(v) for v in values])
 
     def qr_image(self):

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -106,7 +106,7 @@ class QRBill:
     """This class represents a Swiss QR Bill."""
     # Header fields
     qr_type = 'SPC'  # Swiss Payments Code
-    version = '0100'
+    version = '0200'
     coding = 1  # Latin character set
     allowed_currencies = ('CHF', 'EUR')
     # QR reference, Creditor Reference (ISO 11649), without reference
@@ -202,9 +202,9 @@ class QRBill:
         """Return data to be encoded in the QR code."""
         values = [self.qr_type, self.version, self.coding, self.account]
         values.extend(self.creditor.data_list())
-        values.extend(self.final_creditor.data_list() if self.final_creditor else [''] * 6)
+        values.extend(self.final_creditor.data_list() if self.final_creditor else [''] * 7)
         values.extend([self.amount or '', self.currency])
-        values.extend(self.debtor.data_list() if self.debtor else [''] * 6)
+        values.extend(self.debtor.data_list() if self.debtor else [''] * 7)
         values.extend([self.ref_type, self.ref_number or '', self.extra_infos, 'EPD'])
         return "\r\n".join([str(v) for v in values])
 

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -145,9 +145,9 @@ class QRBillTests(unittest.TestCase):
         )
         self.assertEqual(
             bill.qr_data(),
-            'SPC\r\n0100\r\n1\r\nCH4431999123000889012\r\nS\r\nJane\r\n\r\n\r\n'
-            '1000\r\nLausanne\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\nCHF\r\n'
-            '\r\n\r\n\r\n\r\n\r\n\r\nNON\r\n\r\n\r\nEPD'
+            'SPC\r\n0200\r\n1\r\nCH4431999123000889012\r\nS\r\nJane\r\n\r\n\r\n'
+            '1000\r\nLausanne\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\nCHF\r\n'
+            '\r\n\r\n\r\n\r\n\r\n\r\n\r\nNON\r\n\r\n\r\nEPD'
         )
         with tempfile.NamedTemporaryFile(suffix='.svg') as fh:
             bill.as_svg(fh.name)
@@ -192,8 +192,8 @@ class QRBillTests(unittest.TestCase):
         '''
         self.assertEqual(
             bill.qr_data(),
-            'SPC\r\n0100\r\n1\r\nCH4431999123000889012\r\nS\r\nRobert Schneider AG\r\n'
-            'Rue du Lac\r\n1268\r\n2501\r\nBiel\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n'
+            'SPC\r\n0200\r\n1\r\nCH4431999123000889012\r\nS\r\nRobert Schneider AG\r\n'
+            'Rue du Lac\r\n1268\r\n2501\r\nBiel\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n'
             '1949.75\r\nCHF\r\nS\r\nPia-Maria Rutschmann-Schnyder\r\nGrosse Marktgasse\r\n'
             '28\r\n9400\r\nRorschach\r\nCH\r\nQRR\r\n210000000003139471430009017\r\n'
             'Order of 15.09.2019##S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086'


### PR DESCRIPTION
I put two commits in one PR because they both concern proper validation of the generated QR-code and the seconds commit won't apply to master properly without the first commit being there alredy.

---

fix QR-code

the generated QR-code did not validate on the
validation portal of iso-payments.ch

- Version 0100 is no longer supported, the currently
  supported version is 0200.

- The address records (Class Address) do have 6 fields,
  but when creating the QR-code, the AdrTp (address type)
  field must be added too (done in Address.data_list).
  The shortcut used in qr_data, when one of the address
  containers is empty, only created 6 empty fields,
  forgetting the AdrTp field which must be presen too.

---

fix problem in QR-code data

If no extra_infos was given, the value used in the
actual QR-code was None. To work around this, use
or '' for all parameters which are not of type address

Somehow the problem does not show up in the tests, but
only in the QR-code picture itself, which can only be
seen when actually decoding the QR-code back to
textual form.