### PR TITLE
remove problematic colons from default output path

### DIFF
--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -107,6 +107,6 @@ if __name__ == '__main__':
     else:
         out_path = "{}-{}.svg".format(
             args.account.replace(' ', ''),
-            datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+            datetime.now().strftime("%Y-%m-%d_%H%M%S")
         )
     bill.as_svg(out_path)


### PR DESCRIPTION
colons in a filename need to be quoted and are cumbersome
to use (on unix platforms at least) and they prevent the
files from being used without renaming in the validation
portal of iso-payments.ch