### PR TITLE
err out when ultimate creditor is used

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -177,10 +177,6 @@ class QRBill:
             # All the code is there and ready to be used; so simply prevent
             # users from accessing it.
             raise ValueError("final creditor is reserved for future use, must not be used")
-#            try:
-#                self.final_creditor = Address(**final_creditor)
-#            except ValueError as err:
-#                raise ValueError("The final creditor address is invalid: %s" % err)
         else:
             self.final_creditor = final_creditor
         if debtor is not None:

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -171,10 +171,16 @@ class QRBill:
         except ValueError as err:
             raise ValueError("The creditor address is invalid: %s" % err)
         if final_creditor is not None:
-            try:
-                self.final_creditor = Address(**final_creditor)
-            except ValueError as err:
-                raise ValueError("The final creditor address is invalid: %s" % err)
+            # The standard says ultimate creditor is reserved for future use.
+            # The online validator does not properly validate QR-codes where
+            # this is set, saying it must not (yet) be used.
+            # All the code is there and ready to be used; so simply prevent
+            # users from accessing it.
+            raise ValueError("final creditor is reserved for future use, must not be used")
+#            try:
+#                self.final_creditor = Address(**final_creditor)
+#            except ValueError as err:
+#                raise ValueError("The final creditor address is invalid: %s" % err)
         else:
             self.final_creditor = final_creditor
         if debtor is not None:

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -154,6 +154,19 @@ class QRBillTests(unittest.TestCase):
             content = fh.read().decode()
         self.assertTrue(content.startswith('<?xml version="1.0" encoding="utf-8" ?>'))
 
+    def test_ultimate_creditor(self):
+        bill_data = {
+            'account': "CH 44 3199 9123 0008 89012",
+            'creditor': {
+                'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
+            },
+            'final_creditor': {
+                'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "final creditor is reserved for future use, must not be used"):
+            QRBill(**bill_data)
+
     def test_spec_example1(self):
         bill = QRBill(
             account='CH4431999123000889012',


### PR DESCRIPTION
UltmtCdtr (ulimate creditor) is in the specs. However,
it is marked as 'for future use' and the fields flagged as
'do not fill in'. The online validator also rejects QR-codes
where these fields are not empty.
As it might be used in a future version of the standard,
do not remove the already working code, but rather return
an error if the structure is attempted to be used.