### PR TITLE
add thousands separator as per spec

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -8,6 +8,7 @@ import qrcode.image.svg
 import svgwrite
 from iso3166 import countries
 from stdnum import iban, iso11649
+from stdnum.ch import esr
 
 IBAN_ALLOWED_COUNTRIES = ['CH', 'LI']
 AMOUNT_REGEX = r'^\d{1,9}\.\d{2}$'
@@ -169,8 +170,6 @@ class QRBill:
             # The standard says ultimate creditor is reserved for future use.
             # The online validator does not properly validate QR-codes where
             # this is set, saying it must not (yet) be used.
-            # All the code is there and ready to be used; so simply prevent
-            # users from accessing it.
             raise ValueError("final creditor is reserved for future use, must not be used")
         else:
             self.final_creditor = final_creditor
@@ -191,9 +190,9 @@ class QRBill:
                 self.ref_number = iso11649.validate(ref_number)
             else:
                 raise ValueError("The reference number is invalid")
-        elif len(ref_number) == 27:
+        elif esr.is_valid(ref_number):
             self.ref_type = 'QRR'
-            self.ref_number = ref_number
+            self.ref_number = esr.format(ref_number).replace(" ", "")
         else:
             raise ValueError("The reference number is invalid")
 
@@ -466,12 +465,9 @@ def format_ref_number(bill):
         return ''
     num = bill.ref_number
     if bill.ref_type == "QRR":
-        return ' '.join([
-            num[:2], num[2:7], num[7:12], num[12:17], num[17:22], num[22:]
-        ])
+        return esr.format(num)
     elif bill.ref_type == "SCOR":
-        # In python-stdnum 1.13: return iso11649.format(num)
-        return ' '.join([num[i:i+4] for i in range(0, len(num), 4)])
+        return iso11649.format(num)
     else:
         return num
 

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -342,7 +342,8 @@ class QRBill:
         dwg.add(dwg.text(self.label("Amount"), (add_mm(margin, '12mm'), '80mm'), **head_font_info))
         dwg.add(dwg.text(self.currency, (margin, '85mm'), **font_info))
         if self.amount:
-            dwg.add(dwg.text(self.amount, (add_mm(margin, '12mm'), '85mm'), **font_info))
+            dwg.add(dwg.text('{:,.2f}'.format(float(self.amount)).replace(",", " "),
+                             (add_mm(margin, '12mm'), '85mm'), **font_info))
         else:
             self.draw_blank_rect(
                 dwg, x=add_mm(margin, '25mm'), y='77mm',
@@ -394,7 +395,8 @@ class QRBill:
         dwg.add(dwg.text(self.label("Amount"), (add_mm(payment_left, '12mm'), '80mm'), **head_font_info))
         dwg.add(dwg.text(self.currency, (payment_left, '85mm'), **font_info))
         if self.amount:
-            dwg.add(dwg.text(self.amount, (add_mm(payment_left, '12mm'), '85mm'), **font_info))
+            dwg.add(dwg.text('{:,.2f}'.format(float(self.amount)).replace(",", " "),
+                             (add_mm(payment_left, '12mm'), '85mm'), **font_info))
         else:
             self.draw_blank_rect(
                 dwg, x=add_mm(receipt_width, margin, '12mm'), y='83mm',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qrbill
-version = 0.4.dev1
+version = 0.5
 description = A library to generate Swiss QR-bill payment slips
 long_description = file: README.rst
 license = GPLv3

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ scripts =
     scripts/qrbill
 install_requires =
     iso3166
-    python-stdnum>=1.12
+    python-stdnum>=1.13
     qrcode
     svgwrite
 test_suite = tests

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -191,7 +191,7 @@ class QRBillTests(unittest.TestCase):
                 'city': 'Biel',
                 'country': 'CH',
             },
-            amount='1949.75',
+            amount='1949.7',
             currency='CHF',
             due_date='2019-10-31',
             debtor={
@@ -220,7 +220,7 @@ class QRBillTests(unittest.TestCase):
             bill.qr_data(),
             'SPC\r\n0200\r\n1\r\nCH4431999123000889012\r\nS\r\nRobert Schneider AG\r\n'
             'Rue du Lac\r\n1268\r\n2501\r\nBiel\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n'
-            '1949.75\r\nCHF\r\nS\r\nPia-Maria Rutschmann-Schnyder\r\nGrosse Marktgasse\r\n'
+            '1949.70\r\nCHF\r\nS\r\nPia-Maria Rutschmann-Schnyder\r\nGrosse Marktgasse\r\n'
             '28\r\n9400\r\nRorschach\r\nCH\r\nQRR\r\n210000000003139471430009017\r\n'
             'Order of 15.09.2019##S1/01/20170309/11/10201409/20/14000000/22/36958/30/CH106017086'
             '/40/1020/41/3010\r\nEPD'
@@ -246,6 +246,13 @@ class QRBillTests(unittest.TestCase):
         # IBAN formatted
         self.assertIn(
             '<text {font10} x="5mm" y="18.5mm">CH44 3199 9123 0008 8901 2</text>'.format(
+                font10=font10
+            ),
+            content
+        )
+        # amount formatted
+        self.assertIn(
+            '<text {font10} x="17.0mm" y="85mm">1 949.70</text>'.format(
                 font10=font10
             ),
             content
@@ -292,7 +299,6 @@ class QRBillTests(unittest.TestCase):
             bill = QRBill(**min_data, ref_number='ref-number')
         with self.assertRaisesRegex(ValueError, "A QR-IBAN requires a QRR reference number"):
             bill = QRBill(**min_data, ref_number='RF18539007547034')
-
 
 
 class CommandLineTests(unittest.TestCase):

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -27,19 +27,19 @@ class QRBillTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "The account parameter is mandatory"):
             QRBill()
         with self.assertRaisesRegex(ValueError, "Creditor information is mandatory"):
-            QRBill(account="CH4431999123000889012")
+            QRBill(account="CH5380005000010283664")
 
     def test_account(self):
         with self.assertRaisesRegex(ValueError, "Sorry, the IBAN is not valid"):
             bill = QRBill(
-                account="CH44319991230008890",
+                account="CH53800050000102836",
                 creditor={
                     'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
                 },
             )
         with self.assertRaisesRegex(ValueError, "Sorry, the IBAN is not valid"):
             bill = QRBill(
-                account="CH4431999123000899012",
+                account="CH5380005000010288664",
                 creditor={
                     'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
                 },
@@ -53,16 +53,16 @@ class QRBillTests(unittest.TestCase):
             )
         # Spaces are auto-stripped
         bill = QRBill(
-            account="CH 44 3199 9123 0008 89012",
+            account="CH 53 8000 5000 0102 83664",
             creditor={
                 'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
             },
         )
-        self.assertEqual(bill.account, "CH4431999123000889012")
+        self.assertEqual(bill.account, "CH5380005000010283664")
 
     def test_country(self):
         bill_data = {
-            'account': 'CH4431999123000889012',
+            'account': 'CH5380005000010283664',
             'creditor': {
                 'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
             },
@@ -86,14 +86,14 @@ class QRBillTests(unittest.TestCase):
     def test_currency(self):
         with self.assertRaisesRegex(ValueError, "Currency can only contain: CHF, EUR"):
             bill = QRBill(
-                account="CH 44 3199 9123 0008 89012",
+                account="CH 53 8000 5000 0102 83664",
                 currency="USD",
                 creditor={
                     'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
                 },
             )
         bill = QRBill(
-                account="CH 44 3199 9123 0008 89012",
+                account="CH 53 8000 5000 0102 83664",
                 currency="CHF",
                 creditor={
                     'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
@@ -101,7 +101,7 @@ class QRBillTests(unittest.TestCase):
             )
         self.assertEqual(bill.currency, "CHF")
         bill = QRBill(
-            account="CH 44 3199 9123 0008 89012",
+            account="CH 53 8000 5000 0102 83664",
             currency="EUR",
             creditor={
                 'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
@@ -125,7 +125,7 @@ class QRBillTests(unittest.TestCase):
         for value, err in unvalid_inputs:
             with self.assertRaisesRegex(ValueError, err):
                 bill = QRBill(
-                    account="CH 44 3199 9123 0008 89012",
+                    account="CH 53 8000 5000 0102 83664",
                     amount=value,
                     creditor={
                         'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
@@ -141,7 +141,7 @@ class QRBillTests(unittest.TestCase):
         ]
         for value, expected in valid_inputs:
             bill = QRBill(
-                    account="CH 44 3199 9123 0008 89012",
+                    account="CH 53 8000 5000 0102 83664",
                     amount=value,
                     creditor={
                         'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne', 'country': 'CH',
@@ -151,14 +151,14 @@ class QRBillTests(unittest.TestCase):
 
     def test_minimal_data(self):
         bill = QRBill(
-            account="CH 44 3199 9123 0008 89012",
+            account="CH 53 8000 5000 0102 83664",
             creditor={
                 'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
             },
         )
         self.assertEqual(
             bill.qr_data(),
-            'SPC\r\n0200\r\n1\r\nCH4431999123000889012\r\nS\r\nJane\r\n\r\n\r\n'
+            'SPC\r\n0200\r\n1\r\nCH5380005000010283664\r\nS\r\nJane\r\n\r\n\r\n'
             '1000\r\nLausanne\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\nCHF\r\n'
             '\r\n\r\n\r\n\r\n\r\n\r\n\r\nNON\r\n\r\n\r\nEPD'
         )
@@ -169,7 +169,7 @@ class QRBillTests(unittest.TestCase):
 
     def test_ultimate_creditor(self):
         bill_data = {
-            'account': "CH 44 3199 9123 0008 89012",
+            'account': "CH 53 8000 5000 0102 83664",
             'creditor': {
                 'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
             },
@@ -253,7 +253,7 @@ class QRBillTests(unittest.TestCase):
 
     def test_reference(self):
         min_data = {
-            'account': "CH 44 3199 9123 0008 89012",
+            'account': "CH 53 8000 5000 0102 83664",
             'creditor': {
                 'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
             },
@@ -267,10 +267,32 @@ class QRBillTests(unittest.TestCase):
         self.assertEqual(format_ref_number(bill), 'RF18 5390 0754 7034')
         with self.assertRaisesRegex(ValueError, "The reference number is invalid"):
             bill = QRBill(**min_data, ref_number='RF19539007547034')
+        with self.assertRaisesRegex(ValueError, "A QRR reference number is only allowed for a QR-IBAN"):
+            bill = QRBill(**min_data, ref_number='18 78583')
 
+        min_data = {
+            'account': "CH 44 3199 9123 0008 89012",
+            'creditor': {
+                'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
+            },
+        }
         bill = QRBill(**min_data, ref_number='210000000003139471430009017')
         self.assertEqual(bill.ref_type, 'QRR')
         self.assertEqual(format_ref_number(bill), '21 00000 00003 13947 14300 09017')
+
+        # check leading zeros
+        bill = QRBill(**min_data, ref_number='18 78583')
+        self.assertEqual(bill.ref_type, 'QRR')
+        self.assertEqual(format_ref_number(bill), '00 00000 00000 00000 00018 78583')
+
+        # invalid QRR
+        with self.assertRaisesRegex(ValueError, "The reference number is invalid"):
+            bill = QRBill(**min_data, ref_number='18539007547034')
+        with self.assertRaisesRegex(ValueError, "The reference number is invalid"):
+            bill = QRBill(**min_data, ref_number='ref-number')
+        with self.assertRaisesRegex(ValueError, "A QR-IBAN requires a QRR reference number"):
+            bill = QRBill(**min_data, ref_number='RF18539007547034')
+
 
 
 class CommandLineTests(unittest.TestCase):
@@ -287,7 +309,7 @@ class CommandLineTests(unittest.TestCase):
     def test_minimal_args(self):
         with tempfile.NamedTemporaryFile(suffix='.svg') as tmp:
             out, err = subprocess.Popen([
-                sys.executable, 'scripts/qrbill', '--account', 'CH 44 3199 9123 0008 89012',
+                sys.executable, 'scripts/qrbill', '--account', 'CH 53 8000 5000 0102 83664',
                 '--creditor-name',  'Jane', '--creditor-postalcode', '1000',
                 '--creditor-city', 'Lausanne',
                 '--output', tmp.name,


### PR DESCRIPTION
according to the specs the amount should use a blank as a thousands
separator on the printout (receipt and payment part)
    
- https://www.paymentstandards.ch/dam/downloads/ig-qr-bill-en.pdf
  version 2.1 effective 2019-Sep-30
  sections 3.5.3 and 3.6.3