### PR TITLE
bump version to v0.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = qrbill
-version = 0.4.dev1
+version = 0.4
 description = A library to generate Swiss QR-bill payment slips
 long_description = file: README.rst
 license = GPLv3


### PR DESCRIPTION
With the switch to the new version of python-stdnum, the additional checking for QR-IBAN and according reference number and the proper formating of amounts on the printout, I think a bump to a higher version number is in line.