### PR TITLE
fix: use qr ERROR_CORRECT_M

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -279,7 +279,7 @@ class QRBill:
         return qrcode.make(
             self.qr_data(),
             image_factory=factory,
-            error_correction=qrcode.constants.ERROR_CORRECT_L,
+            error_correction=qrcode.constants.ERROR_CORRECT_M,
         )
 
     def draw_swiss_cross(self, dwg, qr_width):


### PR DESCRIPTION
According to the spec, this should be M and not L.