### PR TITLE
fix: missing country in CombinedAddress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 ChangeLog
 =========
 
+Unreleased
+----------
+
+- Fix for missing country field in QR code when using CombinedAddress (#31)
+
 0.5 (2020-06-24)
 ----------------
 

--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -57,11 +57,11 @@ class Address:
     def create(cls, **kwargs):
         if kwargs.get('line1') or kwargs.get('line2'):
             for arg_name in ('street', 'house_num', 'pcode', 'city'):
-                if kwargs.get(arg_name):
+                if kwargs.pop(arg_name, False):
                     raise ValueError("When providing line1 or line2, you cannot provide %s" % arg_name)
             if not kwargs.get('line2'):
                 raise ValueError("line2 is mandatory for combined address type.")
-            return CombinedAddress(name=kwargs['name'], line1=kwargs['line1'], line2=kwargs['line2'])
+            return CombinedAddress(**kwargs)
         else:
             kwargs.pop('line1', None)
             kwargs.pop('line2', None)
@@ -97,7 +97,7 @@ class CombinedAddress(Address):
     def data_list(self):
         # 'K': combined address
         return [
-            'K', self.name, self.line1, self.line2, '', '', ''
+            'K', self.name, self.line1, self.line2, '', '', self.country
         ]
 
     def as_paragraph(self):

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -74,25 +74,35 @@ class QRBillTests(unittest.TestCase):
     def test_country(self):
         bill_data = {
             'account': 'CH5380005000010283664',
-            'creditor': {
-                'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
-            },
         }
-        # Switzerland - German/French/Italian/Romansh/English/code
-        for country_name in ('Schweiz', 'Suisse', 'Svizzera', 'Svizra', 'Switzerland', 'CH'):
-            bill_data['creditor']['country'] = country_name
-            bill = QRBill(**bill_data)
-            self.assertEqual(bill.creditor.country, 'CH')
+        for creditor in [
+            {
+                'name': 'Jane',
+                'pcode': '1000',
+                'city': 'Lausanne',
+            },
+            {
+                'name': 'Jane',
+                'line1': 'rue de foo 123',
+                'line2': '1000 Lausanne',
+            },
+        ]:
+            bill_data["creditor"] = creditor
+            # Switzerland - German/French/Italian/Romansh/English/code
+            for country_name in ('Schweiz', 'Suisse', 'Svizzera', 'Svizra', 'Switzerland', 'CH'):
+                bill_data['creditor']['country'] = country_name
+                bill = QRBill(**bill_data)
+                self.assertEqual(bill.creditor.country, 'CH')
 
-        # Liechtenstein - short and long names/code
-        for country_name in ('Liechtenstein', 'Fürstentum Liechtenstein', 'LI'):
-            bill_data['creditor']['country'] = country_name
-            bill = QRBill(**bill_data)
-            self.assertEqual(bill.creditor.country, 'LI')
+            # Liechtenstein - short and long names/code
+            for country_name in ('Liechtenstein', 'Fürstentum Liechtenstein', 'LI'):
+                bill_data['creditor']['country'] = country_name
+                bill = QRBill(**bill_data)
+                self.assertEqual(bill.creditor.country, 'LI')
 
-        with self.assertRaisesRegex(ValueError, "The country code 'XY' is not valid"):
-            bill_data['creditor']['country'] = 'XY'
-            bill = QRBill(**bill_data)
+            with self.assertRaisesRegex(ValueError, "The country code 'XY' is not valid"):
+                bill_data['creditor']['country'] = 'XY'
+                bill = QRBill(**bill_data)
 
     def test_currency(self):
         with self.assertRaisesRegex(ValueError, "Currency can only contain: CHF, EUR"):


### PR DESCRIPTION
CombinedAddresses were missing the country field, which is necessary just like in the structured address.

Test case:
```
python scripts/qrbill --account 'CH 53 8000 5000 0102 83664' --creditor-name 'Jane' --creditor-line1 'asdfasdf' --creditor-line2 '1000 Lausanne' --creditor-country 'Cuba'
```

Validation using https://www.swiss-qr-invoice.org/validator/