### PR TITLE
feat: add option to render to A4 size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ ChangeLog
 Unreleased
 ----------
 
-- Fix for missing country field in QR code when using CombinedAddress (#31)
+- Fix for missing country field in QR code when using CombinedAddress (#31).
+- Added support for printing bill to full A4 format, using the ``full_page``
+  parameter of ``QRBill.as_svg()`` or the CLI argument ``--full-page``.
 
 0.5 (2020-06-24)
 ----------------

--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -74,6 +74,9 @@ if __name__ == '__main__':
     parser.add_argument('--language', default='en', choices=['en', 'de', 'fr', 'it'],
                         help='language')
 
+    parser.add_argument('--full-page', default=False, action='store_true',
+                        help='Print to full A4 size page')
+
     args = parser.parse_args()
     creditor = {
         'name': args.creditor_name,
@@ -121,4 +124,4 @@ if __name__ == '__main__':
             args.account.replace(' ', ''),
             datetime.now().strftime("%Y-%m-%d_%H%M%S")
         )
-    bill.as_svg(out_path)
+    bill.as_svg(out_path, full_page=args.full_page)


### PR DESCRIPTION
There's an issue which I couldn't resolve, being that the y-translation does not go far enough to the end of the page.
Thus I had to add a magic number to do this.

Note that rendering the "Separate before paying in" label had to be placed using the (correctly) calculated offset.

Any idea why the transform=translate() doesn't do what we need?


[Example](https://user-images.githubusercontent.com/5493667/86929899-a93d8f00-c136-11ea-83a6-edc085256790.png) with bad png conversion...
