### PR TITLE
make separation lines optional

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -169,7 +169,7 @@ class QRBill:
     def __init__(
             self, account=None, creditor=None, final_creditor=None, amount=None,
             currency='CHF', due_date=None, debtor=None, ref_number=None, extra_infos='',
-            language='en', top_line=True):
+            language='en', top_line=True, payment_line=True):
         # Account (IBAN) validation
         if not account:
             raise ValueError("The account parameter is mandatory")
@@ -272,6 +272,7 @@ class QRBill:
             raise ValueError("Language should be 'en', 'de', 'fr', or 'it'")
         self.language = language
         self.top_line = top_line
+        self.payment_line = payment_line
 
     def qr_data(self):
         """Return data to be encoded in the QR code."""
@@ -458,14 +459,15 @@ class QRBill:
             ))
 
         # Separation line between receipt and payment parts
-        grp.add(dwg.line(
-            start=(mm(RECEIPT_WIDTH), 0), end=(mm(RECEIPT_WIDTH), mm(BILL_HEIGHT)),
-            stroke='black', stroke_dasharray='2 2'
-        ))
-        grp.add(dwg.text(
-            "✂", insert=(add_mm(RECEIPT_WIDTH, mm(-1.5)), 40),
-            font_size=16, font_family='helvetica', rotate=[90]
-        ))
+        if self.payment_line:
+            grp.add(dwg.line(
+                start=(mm(RECEIPT_WIDTH), 0), end=(mm(RECEIPT_WIDTH), mm(BILL_HEIGHT)),
+                stroke='black', stroke_dasharray='2 2'
+            ))
+            grp.add(dwg.text(
+                "✂", insert=(add_mm(RECEIPT_WIDTH, mm(-1.5)), 40),
+                font_size=16, font_family='helvetica', rotate=[90]
+            ))
 
         # Payment part
         grp.add(dwg.text(self.label("Payment part"), (payment_left, mm(10)), **self.title_font_info))

--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -75,6 +75,10 @@ if __name__ == '__main__':
                         help='language')
     parser.add_argument('--full-page', default=False, action='store_true',
                         help='Print to full A4 size page')
+    parser.add_argument('--no-top-line', dest="top_line", default=True, action='store_false',
+                        help='Do not print top separation line')
+    parser.add_argument('--no-payment-line', dest="payment_line", default=True, action='store_false',
+                        help='Do not print vertical separation line between receipt and payment parts')
 
     args = parser.parse_args()
     creditor = {
@@ -112,6 +116,8 @@ if __name__ == '__main__':
             ref_number=args.reference_number,
             extra_infos=args.extra_infos,
             language=args.language,
+            top_line=args.top_line,
+            payment_line=args.payment_line,
         )
     except ValueError as err:
         sys.exit("Error: %s" % err)


### PR DESCRIPTION
When printing on perforated paper, the separation lines aren't necessary, so it should be possible to not print them.