### PR TITLE
Fixes #86 - Handle line breaks in additional_information

### DIFF
--- a/qrbill/bill.py
+++ b/qrbill/bill.py
@@ -404,7 +404,7 @@ class QRBill:
         values.extend([
             self.ref_type or '',
             self.reference_number or '',
-            self.additional_information or '',
+            replace_linebreaks(self.additional_information),
         ])
         values.append('EPD')
         values.extend(self.alt_procs)
@@ -792,7 +792,13 @@ def format_amount(amount_):
 
 
 def wrap_infos(infos):
-    for text in infos:
-        while(text):
-            yield text[:MAX_CHARS_PAYMENT_LINE]
-            text = text[MAX_CHARS_PAYMENT_LINE:]
+    for line in infos:
+        for text in line.splitlines():
+            while text:
+                yield text[:MAX_CHARS_PAYMENT_LINE]
+                text = text[MAX_CHARS_PAYMENT_LINE:]
+
+
+def replace_linebreaks(text):
+    text = text or ''
+    return ' '.join(text.splitlines())

--- a/tests/test_qrbill.py
+++ b/tests/test_qrbill.py
@@ -238,6 +238,27 @@ class QRBillTests(unittest.TestCase):
             self.assertEqual(bill.amount, expected)
             self.assertEqual(format_amount(bill.amount), printed)
 
+    def test_additionnal_info_break(self):
+        """
+        Line breaks in additional_information are converted to space in QR data
+        (but still respected on info display)
+        """
+        bill = QRBill(
+            account="CH 53 8000 5000 0102 83664",
+            creditor={
+                'name': 'Jane', 'pcode': '1000', 'city': 'Lausanne',
+            },
+            additional_information="Hello\nLine break",
+        )
+        self.assertEqual(
+            bill.qr_data(),
+            'SPC\r\n0200\r\n1\r\nCH5380005000010283664\r\nS\r\nJane\r\n\r\n\r\n'
+            '1000\r\nLausanne\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\nCHF\r\n'
+            '\r\n\r\n\r\n\r\n\r\n\r\n\r\nNON\r\n\r\nHello Line break\r\nEPD'
+        )
+        with open("test1.svg", 'w') as fh:
+            bill.as_svg(fh.name)
+
     def test_minimal_data(self):
         bill = QRBill(
             account="CH 53 8000 5000 0102 83664",


### PR DESCRIPTION
Line breaks are respected on printed information, but replaced by spaces in encoded QR data.