### PR TITLE
Adds type hints and tooling to verify them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,22 @@ jobs:
       - name: Install dependencies
         run: |
             python -m pip install --upgrade pip
-            python -m pip install flake8
+            python -m pip install -e .[lint]
       - name: Lint with flake8
         run: |
             flake8 .
+      - name: Type checking with mypy
+        run: |
+            mypy -p qrbill --python-version 3.8
+            mypy -p qrbill --python-version 3.9
+            mypy -p qrbill --python-version 3.10
+            mypy -p qrbill --python-version 3.11
+            mypy -p qrbill --python-version 3.12
+            mypy scripts/qrbill --python-version 3.8
+            mypy scripts/qrbill --python-version 3.9
+            mypy scripts/qrbill --python-version 3.10
+            mypy scripts/qrbill --python-version 3.11
+            mypy scripts/qrbill --python-version 3.12
 
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 /build/
 /dist/
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,6 @@
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.pytest.ini_options]
-log_level = "INFO"
-testpaths = ["tests"]
-timeout = 300
-
 [tool.mypy]
 follow_imports = "silent"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+log_level = "INFO"
+testpaths = ["tests"]
+timeout = 300
+
+[tool.mypy]
+follow_imports = "silent"
+strict = true

--- a/qrbill/__init__.py
+++ b/qrbill/__init__.py
@@ -1,1 +1,5 @@
-from .bill import QRBill  # NOQA
+from .bill import QRBill
+
+__all__ = (
+    'QRBill',
+)

--- a/scripts/qrbill
+++ b/scripts/qrbill
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import annotations
 
 import argparse
 import sys
@@ -9,12 +10,12 @@ from importlib import metadata
 from qrbill import QRBill
 
 
-def clean_nl(value):
+def clean_nl(value: str | None) -> str | None:
     """A '\n' in the command line will be escaped to '\\n'."""
     return value.replace('\\n', '\n') if isinstance(value, str) else value
 
 
-def run():
+def run() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('--version', action='version', version='%(prog)s ' + metadata.version('qrbill'))
     parser.add_argument('--output',
@@ -114,7 +115,7 @@ def run():
     try:
         bill = QRBill(
             account=args.account,
-            creditor=creditor,
+            creditor=creditor,  # type: ignore[arg-type]
             amount=args.amount,
             currency=args.currency,
             debtor=debtor,
@@ -144,6 +145,7 @@ def run():
             datetime.now().strftime("%Y-%m-%d_%H%M%S")
         )
     bill.as_svg(out_path, full_page=args.full_page)
+
 
 if __name__ == '__main__':
     run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,21 @@ install_requires =
     python-stdnum>=1.13
     qrcode
     svgwrite
+    typing_extensions
 test_suite = tests
+include_package_data = true
+
+[options.extras_require]
+lint =
+    flake8
+    flake8-type-checking
+    mypy
+    types-qrcode
+
+[options.package_data]
+qrbill =
+    py.typed
 
 [flake8]
 max-line-length = 119
+extend-select = TC1


### PR DESCRIPTION
Since this is a fairly small package I thought I'd contribute type hints for it. If you don't want them, I can extract them into .pyi files and contribute them to typeshed instead.

Eventually we may want to consider using `TypedDict` for the debtor/creditor arguments, in order to increase type safety, but for now I wanted to keep the surface area of the change as small as possible.

I've decided to use PEP-563, so we can use modern type annotation syntax while still supporting Python 3.8/3.9